### PR TITLE
Remove duplicate clauses from resolution FPCs

### DIFF
--- a/src/fpc/resolution/binary_res_fol.mod
+++ b/src/fpc/resolution/binary_res_fol.mod
@@ -12,7 +12,6 @@ orNeg_kc (dlist C1 C2) _  (dlist C1 C2).
 orNeg_kc (dlist2 C1 S) _  (dlist2 C1 S).
 orNeg_kc (dlist3 S) _  (dlist3 S).
 initial_ke (dlist _ _) _.
-initial_ke (dlist _ _) _.
 initial_ke (dlist2 _ _) _.
 initial_ke (dlist3 _) _.
 initial_ke done _.

--- a/src/fpc/resolution/binary_res_fol_nosub.mod
+++ b/src/fpc/resolution/binary_res_fol_nosub.mod
@@ -12,7 +12,6 @@ orNeg_kc (dlist C1 C2) _  (dlist C1 C2).
 orNeg_kc (dlist2 C1) _  (dlist2 C1).
 orNeg_kc dlist3 _  dlist3.
 initial_ke (dlist _ _) _.
-initial_ke (dlist _ _) _.
 initial_ke (dlist2 _) _.
 initial_ke dlist3 _.
 initial_ke done _.
@@ -34,6 +33,4 @@ decide_ke dlist3 lit done.
 false_kc (dlist C1 C2) (dlist C1 C2).
 % clauses are in prefix normal form and we just apply the sub in the right order
 some_ke (dlist2 C) _ (dlist2 C).
-some_ke (dlist2 C) _ (dlist2 C).
-some_ke dlist3 _ dlist3.
 some_ke dlist3 _ dlist3.

--- a/src/fpc/resolution/binary_res_prop.mod
+++ b/src/fpc/resolution/binary_res_prop.mod
@@ -12,7 +12,6 @@ orNeg_kc (dlist C1 C2) _  (dlist C1 C2).
 orNeg_kc (dlist2 C1) _  (dlist2 C1).
 orNeg_kc dlist3 _  dlist3.
 initial_ke (dlist _ _) _.
-initial_ke (dlist _ _) _.
 initial_ke (dlist2 _) _.
 initial_ke dlist3 _.
 initial_ke done _.


### PR DESCRIPTION
Some duplicate clauses for clerks and experts in the resolution FPCs have been found and removed, being semantically redundant and potentially problematic from a search and backtracking perspective.

All tests pass except param1, as referenced in #1.
